### PR TITLE
Introduce MiniTranslatableComponent

### DIFF
--- a/patches/api/0004-Introduce-PluginTranslatableComponent.patch
+++ b/patches/api/0004-Introduce-PluginTranslatableComponent.patch
@@ -1,0 +1,838 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jatyn Stacy <jlee0964@gmail.com>
+Date: Thu, 25 Nov 2021 02:28:53 +0100
+Subject: [PATCH] Introduce PluginTranslatableComponent
+
+This patch implements the plugin translatable component interface and
+implementation that is an additional component that may be used in
+combination with the adventure text api.
+
+A plugin translatable component is a translatable-like component that only
+holds a key that is matched to a localized message when rendered. The
+difference between a translatable component and a plugin translatable
+component is the fact that the translation the plugin translatable
+component represents is parsed using the mini message parser and
+arguments are passed in as a single template resolver.
+
+Besides the addition of the plugin translatable component, this patch
+also introduces a basic layout to allow plugins to quickly load
+translator instances to supply the servers translator with translations
+for the added plugin translatable components.
+
+Co-authored-by: Bjarne Koll <lynxplay101@gmail.com>
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 92b612126a6bac0b89198a92bbb73b742ec9d064..628b75507c12d66cb45917e9f62b2eca7383ae6a 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -37,6 +37,7 @@ dependencies {
+     apiAndDocs("net.kyori:adventure-text-serializer-gson")
+     apiAndDocs("net.kyori:adventure-text-serializer-legacy")
+     apiAndDocs("net.kyori:adventure-text-serializer-plain")
++    api("net.kyori:adventure-text-minimessage:4.2.0-SNAPSHOT") // KTP
+     api("org.apache.logging.log4j:log4j-api:2.14.1") // Paper
+     api("org.slf4j:slf4j-api:1.7.30") // Paper
+ 
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundle.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundle.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..846090a0e05f3a9974b2770178a55846289daa4c
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundle.java
+@@ -0,0 +1,28 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.Locale;
++
++/**
++ * A plugin translation bundle is a collection of all available locales a plugin may be translated including all translation keys and their
++ * translations for each locale.
++ * <p>
++ * The translation bundle to that degree is hence a representation of all registered translations available.
++ */
++public interface PluginTranslationBundle {
++
++    /**
++     * Queries the translation bundle for a specific translation based on the passed locale and translation key.
++     * This query can be expected to be performed in two map lookups and hence can be considered relatively cheap.
++     *
++     * @param locale         the locale to query for. If the translation bundle does not contain the locale at all, no translation will be returned.
++     * @param translationKey the translation key of the translation to find. This is the primary identified. If no translation for the translation key
++     *                       could be found in the locale, no translation is returned.
++     *
++     * @return the translation found in the bundle if the bundled contained both the locale and the locale contained the translation key.
++     */
++    @Nullable String findTranslation(@NotNull Locale locale, @NotNull String translationKey);
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslators.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslators.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..56cdf378ec8a7ba2fc8f1b4cdacc0c70a2cea175
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslators.java
+@@ -0,0 +1,137 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import com.google.common.base.Preconditions;
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import dev.lynxplay.ktp.adventure.translation.parser.TranslationFileParser;
++import dev.lynxplay.ktp.adventure.translation.parser.TranslationLocaleParser;
++import net.kyori.adventure.text.PluginTranslatableComponent;
++import net.kyori.adventure.translation.Translator;
++import org.bukkit.plugin.Plugin;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Path;
++import java.util.Locale;
++
++/**
++ * The plugin translators interface is the main entry point for registering and creating translations for plugins that may be consumed by creating
++ * {@link PluginTranslatableComponent}s.
++ */
++public interface PluginTranslators {
++
++    /**
++     * Parses a complete translation bundle from the filesystem using a locale and file parser.
++     * This method is hence expected to perform IO operations and should be moved off the main server thread.
++     *
++     * @param translationRoot         the root path under which all translation files that should be parsed can be found.
++     * @param translationLocaleParser the locale parser that parses the locale for each file found in the {@code translationRoot}.
++     * @param translationFileParser   the file parser that is to be used to parse each file into a map of translation keys and translations.
++     *
++     * @return the parsed plugin translation bundle including all parsed locales and their translation maps.
++     *
++     * @throws IllegalArgumentException  if the passed {@code translationRoot} does not represent a folder on the filesystem.
++     * @throws TranslationParseException if the translations could not be read, parsed or found in the first place by file parser.
++     */
++    @NotNull PluginTranslationBundle parseTranslationBundle(@NotNull Path translationRoot,
++                                                            @NotNull TranslationLocaleParser translationLocaleParser,
++                                                            @NotNull TranslationFileParser translationFileParser) throws TranslationParseException;
++
++    /**
++     * Creates a new adventure translator that may be registered on the {@link net.kyori.adventure.translation.GlobalTranslator} to take effect.
++     * <p>
++     * This method is a direct delegate to the {@link #createPluginTranslator(String, PluginTranslationBundle)} method by using the plugins name
++     * as a namespace. More specifically {@link Plugin#getName()} converted to lowercase.
++     * <p>
++     * The namespace is prefixed and joined using a plain '.'.
++     * An example would be the translation key 'message.player.join' and the plugin named 'Example' which would produced a final effective translation
++     * key of 'example.message.player.join'
++     *
++     * @param plugin                  the plugin instance that defines the namespace this plugin translator should be responsible for.
++     * @param pluginTranslationBundle the plugin translation bundle holding all the translations the plugin has for its messages.
++     *
++     * @return the translator instance that is capable of translating all translations in the translation bundle prefixed with the namespace.
++     */
++    default @NotNull Translator createPluginTranslator(@NotNull Plugin plugin, @NotNull PluginTranslationBundle pluginTranslationBundle) {
++        Preconditions.checkNotNull(plugin, "The passed plugin was null");
++        return this.createPluginTranslator(plugin.getName().toLowerCase(Locale.ROOT), pluginTranslationBundle);
++    }
++
++    /**
++     * Creates a new adventure translator that may be registered on the {@link net.kyori.adventure.translation.GlobalTranslator} to take effect.
++     * <p>
++     * This method is a direct delegate to the {@link #createPluginTranslator(String, PluginTranslationBundle)} method by using the plugins name
++     * as a namespace. More specifically {@link Plugin#getName()} converted to lowercase.
++     * <p>
++     * The namespace is prefixed and joined using a plain '.'.
++     * An example would be the translation key 'message.player.join' and the plugin named 'Example' which would produced a final effective translation
++     * key of 'example.message.player.join'
++     *
++     * @param namespace               the namespace this plugin translator should be responsible for.
++     * @param pluginTranslationBundle the plugin translation bundle holding all the translations the plugin has for its messages.
++     *
++     * @return the translator instance that is capable of translating all translations in the translation bundle prefixed with the namespace.
++     */
++    @NotNull Translator createPluginTranslator(@NotNull String namespace, @NotNull PluginTranslationBundle pluginTranslationBundle);
++
++    /**
++     * Provides a static immutable implementation of the translation file parser that is capable of parsing yaml files.
++     * Yaml files are parsed by constructing the translation key as a combination of each node above a value.
++     * <p>
++     * Example given:
++     * <pre>
++     * message:
++     *   player:
++     *     join: 'You joined the game'
++     * </pre>
++     * would be parsed into a single translation, namely the translation key 'message.player.join' mapped to 'You joined the game'.
++     *
++     * @return the yaml parser instance.
++     */
++    @NotNull TranslationFileParser yamlTranslationFileParser();
++
++    /**
++     * Provides a static immutable implementation of the translation file parser that is capable of parsing properties files.
++     * Since properties files cannot contain hierarchical data, the mappings are taken verbatim from the file.
++     * <p>
++     * Example given:
++     * <pre>
++     *  message.player.join=You joined the game
++     * </pre>
++     * would be parsed as a translation mapping the key 'message.player.join' to the value 'You joined the game'.
++     *
++     * @return the properties parser instance.
++     */
++    @NotNull TranslationFileParser propertiesTranslationFileParser();
++
++    /**
++     * Provides a static immutable implementation of the translation file parser that is capable of parsing json files.
++     * Json files are parsed by constructing the translation key as a combination of each node above a value.
++     * <p>
++     * Example given:
++     * <pre>
++     * {
++     *   "message": {
++     *     "player": {
++     *       "join": "You joined the game"
++     *     }
++     *   }
++     * }
++     * </pre>
++     * would be parsed into a single translation, namely the translation key 'message.player.join' mapped to 'You joined the game'.
++     *
++     * @return the json parser instance.
++     */
++    @NotNull TranslationFileParser jsonTranslationFileParser();
++
++    /**
++     * Provides a static immutable implementation of the translation locale parser that parses the locale of a file simply based on the base file
++     * name, ignoring the extension.
++     * <p>
++     * Example given:
++     * The file 'plugins/Example/language/en.json' would be parsed to {@link java.util.Locale#ENGLISH}.
++     * Notably this uses {@link net.kyori.adventure.translation.Translator#parseLocale(String)}, so country code and variants are also accepted.
++     *
++     * @return the file name based locale parser.
++     */
++    @NotNull TranslationLocaleParser filenameTranslationLocaleParser();
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationLocaleParserException.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationLocaleParserException.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c705749f71f73a6acd8de48913826a7919b42e88
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationLocaleParserException.java
+@@ -0,0 +1,19 @@
++package dev.lynxplay.ktp.adventure.translation.exception;
++
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * A plain runtime exception that may be thrown if a locale parser fails to parse the locale of a translation file.
++ */
++public final class TranslationLocaleParserException extends RuntimeException {
++
++    /**
++     * Creates a new locale parser exception.
++     *
++     * @param message the message that contains more detailed information about why the exception is thrown.
++     */
++    public TranslationLocaleParserException(@NotNull String message) {
++        super(message);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationParseException.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationParseException.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..8e7760bd8f43dd854d6364f94fb9b14a807be5ae
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/exception/TranslationParseException.java
+@@ -0,0 +1,30 @@
++package dev.lynxplay.ktp.adventure.translation.exception;
++
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * A plain runtime exception that may be thrown if translations failed to be parsed from the filesystem due to os level exception or format
++ * exceptions.
++ */
++public final class TranslationParseException extends RuntimeException {
++
++    /**
++     * Creates a new translation parse exception.
++     *
++     * @param message the message that contains more detailed information about why the exception is thrown.
++     */
++    public TranslationParseException(@NotNull String message) {
++        super(message);
++    }
++
++    /**
++     * Creates a new translation parse exception.
++     *
++     * @param message the message that contains more detailed information about why the exception is thrown.
++     * @param cause   the underlying throwable that caused this exception to be thrown.
++     */
++    public TranslationParseException(String message, Throwable cause) {
++        super(message, cause);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationFileParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationFileParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3fbb1df01ab11c18fadfaecaec13ba356024e4d4
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationFileParser.java
+@@ -0,0 +1,25 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Path;
++import java.util.Map;
++
++/**
++ * A file parser that reads in a file and converts it into a map of translations keys to their respective translation.
++ */
++public interface TranslationFileParser {
++
++    /**
++     * Parses a file found on the systems file system into a map of translations keys to their respective translations.
++     *
++     * @param file the file to parse represented as a java path.
++     *
++     * @return the constructed map of translations keys to translations.
++     *
++     * @throws TranslationParseException if the file parser failed to parse the file located at the given path for whatever reason.
++     */
++    @NotNull Map<String, String> parseTranslations(@NotNull Path file) throws TranslationParseException;
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationLocaleParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationLocaleParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..6af66024b8c8adf7aac86578581cff8e15d0ea8b
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/TranslationLocaleParser.java
+@@ -0,0 +1,26 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationLocaleParserException;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Path;
++import java.util.Locale;
++
++/**
++ * A parser that converts translation file paths to the locale they hold translations for.
++ */
++@FunctionalInterface
++public interface TranslationLocaleParser {
++
++    /**
++     * Parses the locale of a translation file using a translations file {@link Path}.
++     *
++     * @param path the path of the translations file.
++     *
++     * @return the parsed locale the translations file represents.
++     *
++     * @throws TranslationLocaleParserException if the parser failed to parse a locale from the path provided.
++     */
++    @NotNull Locale parseLocale(@NotNull Path path) throws TranslationLocaleParserException;
++
++}
+diff --git a/src/main/java/net/kyori/adventure/text/KTPComponents.java b/src/main/java/net/kyori/adventure/text/KTPComponents.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..577480bc6ca65b91f6f6ea0d793ad9237f99355a
+--- /dev/null
++++ b/src/main/java/net/kyori/adventure/text/KTPComponents.java
+@@ -0,0 +1,88 @@
++package net.kyori.adventure.text;
++
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * KTP-API specific methods and constants that may be used to work with {@link net.kyori.adventure.text.Component}s and
++ * their likes.
++ */
++public class KTPComponents {
++
++    /**
++     * Creates a plugin translatable component fully configured with a key, template resolver and mini message instance.
++     *
++     * @param key                 the translation key of the plugin translatable component.
++     * @param templateResolver    the template resolver that resolves the templates in the translated message.
++     * @param miniMessageInstance the mini message instance that should be used to de-serialize the raw translation string message.
++     *
++     * @return a new immutable plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    public static @NotNull PluginTranslatableComponent pluginTranslatable(@NotNull final String key,
++                                                                          @NotNull final net.kyori.adventure.text.minimessage.template.TemplateResolver templateResolver,
++                                                                          @NotNull final net.kyori.adventure.text.minimessage.MiniMessage miniMessageInstance) {
++        return new PluginTranslatableComponentImpl(
++            java.util.Collections.emptyList(),
++            net.kyori.adventure.text.format.Style.empty(),
++            key,
++            templateResolver,
++            miniMessageInstance
++        );
++    }
++
++    /**
++     * Creates a plugin translatable component configured with a key and a template resolver.
++     * A default mini message instance will be used.
++     *
++     * @param key              the translation key of the plugin translatable component.
++     * @param templateResolver the template resolver that resolves the templates in the translated message.
++     *
++     * @return a new immutable plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    public static @NotNull PluginTranslatableComponent pluginTranslatable(@NotNull final String key,
++                                                                          @NotNull final net.kyori.adventure.text.minimessage.template.TemplateResolver templateResolver) {
++        return new PluginTranslatableComponentImpl(
++            java.util.Collections.emptyList(),
++            net.kyori.adventure.text.format.Style.empty(),
++            key,
++            templateResolver,
++            net.kyori.adventure.text.minimessage.MiniMessage.miniMessage()
++        );
++    }
++
++    /**
++     * Creates a plugin translatable component configured with a key.
++     * An empty template resolver will be used, meaning no templates will be resolved. Additionally, a default mini message instance will be used.
++     *
++     * @param key the translation key of the plugin translatable component.
++     *
++     * @return a new immutable plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    public static @NotNull PluginTranslatableComponent pluginTranslatable(@NotNull final String key) {
++        return new PluginTranslatableComponentImpl(
++            java.util.Collections.emptyList(),
++            net.kyori.adventure.text.format.Style.empty(),
++            key,
++            net.kyori.adventure.text.minimessage.template.TemplateResolver.empty(),
++            net.kyori.adventure.text.minimessage.MiniMessage.miniMessage()
++        );
++    }
++
++    /**
++     * Creates a builder for the plugin translatable component.
++     * The builder is not configured with any default values and will need to be filled.
++     *
++     * @return a mutable builder for the plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    public static @NotNull PluginTranslatableComponent.Builder pluginTranslatable() {
++        return new PluginTranslatableComponentImpl.BuilderImpl();
++    }
++
++}
+diff --git a/src/main/java/net/kyori/adventure/text/PluginTranslatableComponent.java b/src/main/java/net/kyori/adventure/text/PluginTranslatableComponent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c80dd262e902c8bca9ad7559e8a6980985482735
+--- /dev/null
++++ b/src/main/java/net/kyori/adventure/text/PluginTranslatableComponent.java
+@@ -0,0 +1,155 @@
++package net.kyori.adventure.text;
++
++import net.kyori.adventure.text.minimessage.MiniMessage;
++import net.kyori.adventure.text.minimessage.template.TemplateResolver;
++import net.kyori.adventure.translation.Translatable;
++import org.jetbrains.annotations.Contract;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.Objects;
++
++/**
++ * The plugin translatable component is a form a {@link net.kyori.adventure.text.TranslatableComponent}. Similarly to a translatable component
++ * it is constructed using only a {@link net.kyori.adventure.translation.Translatable} key, however the translation of this key is expected
++ * to be representing a translation that is in the mini-message format.
++ */
++public interface PluginTranslatableComponent extends BuildableComponent<PluginTranslatableComponent, PluginTranslatableComponent.Builder>,
++    ScopedComponent<PluginTranslatableComponent> {
++
++    /**
++     * Gets the translation key.
++     *
++     * @return the translation key
++     *
++     * @since 1.17.1
++     */
++    @NotNull String key();
++
++    /**
++     * Sets the translation key.
++     *
++     * @param translatable the translatable object to get the key from
++     *
++     * @return a plugin translatable component
++     *
++     * @since 1.17.1
++     */
++    @Contract(pure = true)
++    default @NotNull PluginTranslatableComponent key(final @NotNull Translatable translatable) {
++        return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
++    }
++
++    /**
++     * Sets the translation key.
++     *
++     * @param key the translation key
++     *
++     * @return a plugin translatable component
++     *
++     * @since 1.17.1
++     */
++    @Contract(pure = true)
++    @NotNull PluginTranslatableComponent key(final @NotNull String key);
++
++    /**
++     * Gets the unmodifiable instance of the template resolver that is currently used by the component to resolve the templates found inside.
++     *
++     * @return the unmodifiable template resolver instance.
++     *
++     * @since 1.17.1
++     */
++    @NotNull TemplateResolver templateResolver();
++
++    /**
++     * Sets the template resolver that should be used to resolve templates found.
++     *
++     * @param templateResolver the template resolver instance.
++     *
++     * @return a plugin translatable component
++     *
++     * @since 1.17.1
++     */
++    @Contract(pure = true)
++    @NotNull PluginTranslatableComponent templateResolver(final @NotNull TemplateResolver templateResolver);
++
++    /**
++     * Provides the mini message instance to use when rendering the translatable component.
++     *
++     * @return the mini message instance that this component used by the component to render it.
++     *
++     * @since 1.17.1
++     */
++    @NotNull MiniMessage miniMessageInstance();
++
++    /**
++     * Sets the mini message instance to use when rendering the translatable component.
++     *
++     * @param miniMessageInstance the mini message instance that should be used by the component to render it.
++     *
++     * @return a new plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    @Contract(pure = true)
++    @NotNull PluginTranslatableComponent miniMessageInstance(final @NotNull MiniMessage miniMessageInstance);
++
++    /**
++     * A text component builder for the plugin translatable component.
++     *
++     * @since 1.17.1
++     */
++    interface Builder extends ComponentBuilder<PluginTranslatableComponent, PluginTranslatableComponent.Builder> {
++
++        /**
++         * Sets the translation key.
++         *
++         * @param translatable the translatable object to get the key from
++         *
++         * @return this builder
++         *
++         * @since 1.17.1
++         */
++        @Contract(pure = true)
++        default @NotNull PluginTranslatableComponent.Builder key(final @NotNull Translatable translatable) {
++            return this.key(Objects.requireNonNull(translatable, "translatable").translationKey());
++        }
++
++        /**
++         * Sets the translation key.
++         *
++         * @param key the translation key
++         *
++         * @return this builder
++         *
++         * @since 1.17.1
++         */
++        @Contract("_ -> this")
++        @NotNull PluginTranslatableComponent.Builder key(final @NotNull String key);
++
++        /**
++         * Sets the template resolver that should be used to resolve templates found.
++         *
++         * @param templateResolver the template resolver instance.
++         *
++         * @return this builder.
++         *
++         * @since 1.17.1
++         */
++        @Contract(pure = true)
++        @NotNull PluginTranslatableComponent.Builder templateResolver(final @NotNull TemplateResolver templateResolver);
++
++        /**
++         * Sets the mini message instance to use when rendering this translatable component.
++         *
++         * @param miniMessageInstance the mini message instance that should be used by the component to render it.
++         *
++         * @return this builder
++         *
++         * @since 1.17.1
++         */
++        @Contract("_ -> this")
++        @NotNull PluginTranslatableComponent.Builder miniMessageInstance(final @NotNull MiniMessage miniMessageInstance);
++
++    }
++
++}
+diff --git a/src/main/java/net/kyori/adventure/text/PluginTranslatableComponentImpl.java b/src/main/java/net/kyori/adventure/text/PluginTranslatableComponentImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..859b0cc515ace169ff2e3c2cd73a38c919df67e4
+--- /dev/null
++++ b/src/main/java/net/kyori/adventure/text/PluginTranslatableComponentImpl.java
+@@ -0,0 +1,150 @@
++package net.kyori.adventure.text;
++
++import net.kyori.adventure.text.format.Style;
++import net.kyori.adventure.text.minimessage.MiniMessage;
++import net.kyori.adventure.text.minimessage.template.TemplateResolver;
++import net.kyori.examination.ExaminableProperty;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.List;
++import java.util.Objects;
++import java.util.stream.Stream;
++
++import static java.util.Objects.requireNonNull;
++
++final class PluginTranslatableComponentImpl extends AbstractComponent implements PluginTranslatableComponent {
++
++    @NotNull private final String key;
++    @NotNull private final MiniMessage miniMessageInstance;
++    @NotNull private final TemplateResolver templateResolver;
++
++    public PluginTranslatableComponentImpl(@NotNull List<? extends ComponentLike> children,
++                                           @NotNull Style style,
++                                           @NotNull String key, @NotNull TemplateResolver templateResolver, @NotNull MiniMessage miniMessageInstance) {
++        super(children, style);
++        this.key = requireNonNull(key, "key");
++        this.templateResolver = requireNonNull(templateResolver, "templateResolver");
++        this.miniMessageInstance = requireNonNull(miniMessageInstance, "miniMessageInstance");
++    }
++
++    @Override
++    public @NotNull String key() {
++        return this.key;
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent key(@NotNull String key) {
++        requireNonNull(key, "key");
++        return new PluginTranslatableComponentImpl(this.children, this.style, key, this.templateResolver, this.miniMessageInstance);
++    }
++
++    @Override
++    public @NotNull TemplateResolver templateResolver() {
++        return this.templateResolver;
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent templateResolver(@NotNull TemplateResolver templateResolver) {
++        requireNonNull(templateResolver, "templateResolver");
++        return new PluginTranslatableComponentImpl(this.children, this.style, this.key, templateResolver, this.miniMessageInstance);
++    }
++
++    @Override
++    public @NotNull MiniMessage miniMessageInstance() {
++        return this.miniMessageInstance;
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent miniMessageInstance(@NotNull MiniMessage miniMessageInstance) {
++        requireNonNull(miniMessageInstance, "miniMessageInstance");
++        return new PluginTranslatableComponentImpl(this.children, this.style, this.key, this.templateResolver, miniMessageInstance);
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent children(@NotNull List<? extends ComponentLike> children) {
++        requireNonNull(children, "children");
++        return new PluginTranslatableComponentImpl(children, this.style, this.key, this.templateResolver, this.miniMessageInstance);
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent style(@NotNull Style style) {
++        requireNonNull(style, "style");
++        return new PluginTranslatableComponentImpl(this.children, style, this.key, this.templateResolver, this.miniMessageInstance);
++    }
++
++    @Override
++    public boolean equals(final @Nullable Object other) {
++        if (this == other) return true;
++        if (!(other instanceof PluginTranslatableComponent that)) return false;
++        if (!super.equals(other)) return false;
++        return Objects.equals(this.key, that.key()) && Objects.equals(this.templateResolver, that.templateResolver());
++    }
++
++    @Override
++    public int hashCode() {
++        int result = super.hashCode();
++        result = (31 * result) + this.key.hashCode();
++        result = (31 * result) + this.templateResolver.hashCode();
++        result = (31 * result) + this.miniMessageInstance.hashCode();
++        return result;
++    }
++
++    @Override
++    protected @NotNull Stream<? extends ExaminableProperty> examinablePropertiesWithoutChildren() {
++        return Stream.concat(
++            Stream.of(
++                ExaminableProperty.of("key", this.key)
++            ),
++            super.examinablePropertiesWithoutChildren()
++        );
++    }
++
++    @Override
++    public @NotNull PluginTranslatableComponent.Builder toBuilder() {
++        return new BuilderImpl(this);
++    }
++
++    static final class BuilderImpl extends AbstractComponentBuilder<PluginTranslatableComponent, PluginTranslatableComponent.Builder> implements PluginTranslatableComponent.Builder {
++
++        private @Nullable String key;
++        private TemplateResolver templateResolver = TemplateResolver.empty();
++        private MiniMessage miniMessageInstance = MiniMessage.miniMessage();
++
++        BuilderImpl() {
++        }
++
++        BuilderImpl(final @NotNull PluginTranslatableComponent component) {
++            super(component);
++            this.key = component.key();
++            this.templateResolver = component.templateResolver();
++            this.miniMessageInstance = component.miniMessageInstance();
++        }
++
++        @Override
++        public @NotNull PluginTranslatableComponent.Builder key(final @NotNull String key) {
++            this.key = key;
++            return this;
++        }
++
++        @Override
++        public @NotNull PluginTranslatableComponent.Builder templateResolver(@NotNull TemplateResolver templateResolver) {
++            this.templateResolver = templateResolver;
++            return this;
++        }
++
++        @Override
++        public @NotNull PluginTranslatableComponent.Builder miniMessageInstance(@NotNull MiniMessage miniMessageInstance) {
++            this.miniMessageInstance = miniMessageInstance;
++            return this;
++        }
++
++        @Override
++        public @NotNull PluginTranslatableComponentImpl build() {
++            if (this.key == null) throw new IllegalStateException("key must be set");
++            return new PluginTranslatableComponentImpl(this.children, this.buildStyle(), this.key, this.templateResolver, this.miniMessageInstance);
++        }
++
++    }
++
++}
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index c551010f84ac5d3ebc626c253a8f8282924152c4..e28acdbfc326871837014b647aeedf9b7eb3078e 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -2113,6 +2113,15 @@ public final class Bukkit {
+         return server.getDatapackManager();
+     }
+     // Paper end
++    // KTP start
++    /**
++     * Returns the plugin translator of the server that plugins may use to register custom translations.
++     * @return the plugin translator instance.
++     */
++    public static @NotNull dev.lynxplay.ktp.adventure.translation.PluginTranslators pluginTranslators() {
++        return server.pluginTranslators();
++    }
++    // KTP end
+ 
+     @NotNull
+     public static Server.Spigot spigot() {
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index c34cfba8f9ed7e9dbd0b6b8ffef9fba46abff046..f76a9cc37b2e8c9d0bf63bc264531cbf55dc45f9 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1837,4 +1837,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+     @NotNull
+     io.papermc.paper.datapack.DatapackManager getDatapackManager();
+     // Paper end
++
++    // KTP start
++    /**
++     * Returns the plugin translator of the server that plugins may use to register custom translations.
++     * @return the plugin translator instance.
++     */
++    @org.jetbrains.annotations.NotNull dev.lynxplay.ktp.adventure.translation.PluginTranslators pluginTranslators();
++    // KTP end
+ }
+diff --git a/src/test/java/net/kyori/adventure/text/PluginTranslatableComponentImplTest.java b/src/test/java/net/kyori/adventure/text/PluginTranslatableComponentImplTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2b1e0d65dcd0c9644f9576d9f71a95c31b16907e
+--- /dev/null
++++ b/src/test/java/net/kyori/adventure/text/PluginTranslatableComponentImplTest.java
+@@ -0,0 +1,48 @@
++package net.kyori.adventure.text;
++
++import net.kyori.adventure.text.minimessage.MiniMessage;
++import net.kyori.adventure.text.minimessage.template.TemplateResolver;
++import org.junit.Assert;
++import org.junit.Test;
++
++import java.util.HashMap;
++
++public class PluginTranslatableComponentImplTest {
++
++    @Test
++    public void key() {
++        final var component = new PluginTranslatableComponentImpl.BuilderImpl().key("test.key").build();
++        Assert.assertEquals("test.key", component.key());
++
++        final var updateComponent = component.key("test.updated");
++        Assert.assertEquals("test.updated", updateComponent.key());
++    }
++
++    @Test(expected = IllegalStateException.class)
++    public void keyBuilderUnset() {
++        new PluginTranslatableComponentImpl.BuilderImpl().build();
++    }
++
++    @Test
++    public void templateResolver() {
++        final var templateResolverOne = TemplateResolver.pairs(new HashMap<>());
++        final var component = new PluginTranslatableComponentImpl.BuilderImpl().key("test.key").templateResolver(templateResolverOne).build();
++        Assert.assertEquals(templateResolverOne, component.templateResolver());
++
++        final var templateResolverTwo = TemplateResolver.templates();
++        final var updateComponent = component.templateResolver(templateResolverTwo);
++        Assert.assertEquals(templateResolverTwo, updateComponent.templateResolver());
++    }
++
++    @Test
++    public void miniMessageInstance() {
++        final var miniMessageOne = MiniMessage.builder().build();
++        final var component = new PluginTranslatableComponentImpl.BuilderImpl().key("test.key").miniMessageInstance(miniMessageOne).build();
++        Assert.assertEquals(miniMessageOne, component.miniMessageInstance());
++
++        final var miniMessageTwo = MiniMessage.builder().strict(true).build();
++        final var updateComponent = component.miniMessageInstance(miniMessageTwo);
++        Assert.assertEquals(miniMessageTwo, updateComponent.miniMessageInstance());
++    }
++
++}

--- a/patches/server/0004-Introduce-PluginTranslatableComponent.patch
+++ b/patches/server/0004-Introduce-PluginTranslatableComponent.patch
@@ -1,0 +1,742 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jatyn Stacy <jlee0964@gmail.com>
+Date: Fri, 26 Nov 2021 17:23:22 -0800
+Subject: [PATCH] Introduce PluginTranslatableComponent
+
+This patch implements the plugin translatable component interface and
+implementation that is an additional component that may be used in
+combination with the adventure text api.
+
+A plugin translatable component is a translatable-like component that only
+holds a key that is matched to a localized message when rendered. The
+difference between a translatable component and a plugin translatable
+component is the fact that the translation the plugin translatable
+component represents is parsed using the mini message parser and
+arguments are passed in as a single template resolver.
+
+Besides the addition of the plugin translatable component, this patch
+also introduces a basic layout to allow plugins to quickly load
+translator instances to supply the servers translator with translations
+for the added plugin translatable components.
+
+Co-authored-by: Bjarne Koll <lynxplay101@gmail.com>
+
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/text/PluginTranslatableComponentRenderer.java b/src/main/java/dev/lynxplay/ktp/adventure/text/PluginTranslatableComponentRenderer.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..271fe9f1b0c7f5ae7681abae2c05ba864d71f6e9
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/text/PluginTranslatableComponentRenderer.java
+@@ -0,0 +1,63 @@
++package dev.lynxplay.ktp.adventure.text;
++
++import dev.lynxplay.ktp.adventure.translation.PluginShortcutMessageFormat;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.PluginTranslatableComponent;
++import net.kyori.adventure.text.renderer.TranslatableComponentRenderer;
++import net.kyori.adventure.translation.Translator;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.text.MessageFormat;
++import java.util.ArrayList;
++import java.util.Locale;
++
++public final class PluginTranslatableComponentRenderer extends TranslatableComponentRenderer<Locale> {
++
++    private final Translator translator;
++
++    public PluginTranslatableComponentRenderer(Translator translator) {
++        this.translator = translator;
++    }
++
++    @Override
++    public @NotNull Component render(@NotNull Component component, @NotNull Locale context) {
++        if (component instanceof PluginTranslatableComponent pluginTranslatable) {
++            final var format = this.translate(pluginTranslatable.key(), context);
++
++            if (format == null) { // Translation not found, but arguments/children components need rendering
++                final var builder = Component.text(pluginTranslatable.key()).toBuilder();
++                return this.mergeStyleAndOptionallyDeepRender(component, builder, context);
++            }
++
++            final var rawTranslation = (format instanceof PluginShortcutMessageFormat shortcutFormat) ? shortcutFormat.toPattern()
++                : format.format(null, new StringBuffer(), null).toString();
++
++            var rendered = super.render( // This call will take (at least on root level) a component the delegate will understand.
++                pluginTranslatable.miniMessageInstance().deserialize(rawTranslation, pluginTranslatable.templateResolver()),
++                context
++            );
++
++            if (!component.children().isEmpty()) {
++                final var renderedChildren = new ArrayList<Component>(rendered.children().size() + component.children().size());
++                renderedChildren.addAll(rendered.children()); // Prepend mini message parsed children.
++
++                for (final var child : component.children()) {
++                    renderedChildren.add(this.render(child, context)); // Add added children afterwards.
++                }
++
++                rendered = rendered.children(renderedChildren);
++            }
++
++            return rendered;
++        }
++
++        return super.render(component, context);
++    }
++
++    @Override
++    protected @Nullable MessageFormat translate(@NotNull String key, @NotNull Locale context) {
++        return translator.translate(key, context);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/KTPTranslator.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/KTPTranslator.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..37dde18abf6b1d6efcda889d2933baba87769586
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/KTPTranslator.java
+@@ -0,0 +1,18 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import dev.lynxplay.ktp.adventure.text.PluginTranslatableComponentRenderer;
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.translation.GlobalTranslator;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.Locale;
++
++public final class KTPTranslator {
++
++    private static final PluginTranslatableComponentRenderer RENDERER = new PluginTranslatableComponentRenderer(GlobalTranslator.get());
++
++    public static @NotNull Component render(final @NotNull Component component, final @NotNull Locale locale) {
++        return RENDERER.render(component, locale);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginShortcutMessageFormat.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginShortcutMessageFormat.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..92ff57f5544176ecfdba24287df9678e633b85f9
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginShortcutMessageFormat.java
+@@ -0,0 +1,83 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import org.jetbrains.annotations.NotNull;
++
++import java.text.AttributedCharacterIterator;
++import java.text.AttributedString;
++import java.text.Format;
++import java.text.MessageFormat;
++import java.text.ParseException;
++import java.text.ParsePosition;
++import java.util.Locale;
++
++/**
++ * A MessageFormat for when you don't want to format the message :)
++ */
++public class PluginShortcutMessageFormat extends MessageFormat {
++
++    private String unformattedString;
++
++    public PluginShortcutMessageFormat(@NotNull String unformattedString) {
++        super("");
++        this.unformattedString = unformattedString;
++    }
++
++    @Override
++    public void applyPattern(@NotNull String pattern) {
++        this.unformattedString = pattern;
++    }
++
++    @Override
++    public String toPattern() {
++        return this.unformattedString;
++    }
++
++    @Override
++    public void setFormatsByArgumentIndex(@NotNull Format @NotNull [] newFormats) {
++    }
++
++    @Override
++    public void setFormats(@NotNull Format @NotNull [] newFormats) {
++    }
++
++    @Override
++    public void setFormatByArgumentIndex(int argumentIndex, Format newFormat) {
++    }
++
++    @Override
++    public void setFormat(int formatElementIndex, Format newFormat) {
++    }
++
++    @NotNull
++    @Override
++    public Format @NotNull [] getFormatsByArgumentIndex() {
++        return this.getFormats();
++    }
++
++    @NotNull
++    @Override
++    public Format @NotNull [] getFormats() {
++        return new Format[0];
++    }
++
++    @Override
++    public AttributedCharacterIterator formatToCharacterIterator(Object arguments) {
++        return new AttributedString("").getIterator();
++    }
++
++    @Override
++    public Object[] parse(String source, ParsePosition pos) {
++        return new Object[0];
++    }
++
++    @Override
++    public Object[] parse(String source) throws ParseException {
++        return parse(source, null);
++    }
++
++    @Override
++    public Object parseObject(String source, ParsePosition pos) {
++        return source;
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundleImpl.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundleImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ae38ab57186e8d5afed32dd65b335e22c06a26c7
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslationBundleImpl.java
+@@ -0,0 +1,41 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
++import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.ArrayList;
++import java.util.Collections;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++
++/**
++ * A straight forward implementation of the plugin translation bundle that uses a fast util map.
++ */
++public final class PluginTranslationBundleImpl implements PluginTranslationBundle {
++
++    private final Map<Locale, Map<String, String>> localeTranslationMappings;
++
++    public PluginTranslationBundleImpl(@NotNull Map<Locale, Map<String, String>> localeTranslationMappings) {
++        this.localeTranslationMappings = new Object2ObjectOpenHashMap<>();
++        for (final var localeMapEntry : localeTranslationMappings.entrySet()) {
++            this.localeTranslationMappings.put(localeMapEntry.getKey(), new Object2ObjectOpenHashMap<>(localeMapEntry.getValue()));
++        }
++    }
++
++    @Override
++    public @Nullable String findTranslation(@NotNull Locale locale, @NotNull String translationKey) {
++        var translationLocale = localeTranslationMappings.get(locale);
++        if (translationLocale == null) {
++            final var requestedLocaleRange = new Locale.LanguageRange(locale.toLanguageTag());
++            translationLocale = localeTranslationMappings.get(
++                Locale.lookup(Collections.singletonList(requestedLocaleRange), localeTranslationMappings.keySet())
++            );
++        }
++
++        return translationLocale == null ? null : translationLocale.get(translationKey);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslatorsImpl.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslatorsImpl.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a1108ffaf0d9de816b849d888f5af813e99fd6f5
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/PluginTranslatorsImpl.java
+@@ -0,0 +1,71 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import dev.lynxplay.ktp.adventure.translation.parser.*;
++import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
++import net.kyori.adventure.translation.Translator;
++import org.jetbrains.annotations.NotNull;
++
++import java.io.IOException;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++
++/**
++ * The server specific implementation of the plugin translators interface.
++ */
++public final class PluginTranslatorsImpl implements PluginTranslators {
++
++    private final TranslationFileParser YAML_TRANSLATION_FILE_PARSER = new YamlTranslationFileParser();
++    private final TranslationFileParser PROPERTIES_TRANSLATION_FILE_PARSER = new PropertiesTranslationFileParser();
++    private final TranslationFileParser JSON_TRANSLATION_FILE_PARSER = new JsonTranslationFileParser();
++    private final TranslationLocaleParser FILENAME_TRANSLATION_LOCALE_PARSER = new FilenameTranslationLocaleParser();
++
++    @Override
++    public @NotNull PluginTranslationBundle parseTranslationBundle(@NotNull Path translationRoot,
++                                                                   @NotNull TranslationLocaleParser translationLocaleParser,
++                                                                   @NotNull TranslationFileParser translationFileParser) throws TranslationParseException {
++        try {
++            final List<Path> translationFiles = Files.walk(translationRoot).filter(Files::isRegularFile).toList();
++            final Map<Locale, Map<String, String>> localeTranslationMappings = new Reference2ObjectOpenHashMap<>();
++            for (final var translationFile : translationFiles) {
++                final Locale locale = translationLocaleParser.parseLocale(translationFile);
++                final Map<String, String> translations = translationFileParser.parseTranslations(translationFile);
++
++                localeTranslationMappings.computeIfAbsent(locale, i -> new Reference2ObjectOpenHashMap<>()).putAll(translations);
++            }
++
++            return new PluginTranslationBundleImpl(localeTranslationMappings);
++        } catch (final IOException e) {
++            throw new TranslationParseException("Failed to read translation files from disk", e);
++        }
++    }
++
++    @Override
++    public @NotNull Translator createPluginTranslator(@NotNull String namespace, @NotNull PluginTranslationBundle pluginTranslationBundle) {
++        return new SinglePluginTranslator(namespace, pluginTranslationBundle);
++    }
++
++    @Override
++    public @NotNull TranslationFileParser yamlTranslationFileParser() {
++        return this.YAML_TRANSLATION_FILE_PARSER;
++    }
++
++    @Override
++    public @NotNull TranslationFileParser jsonTranslationFileParser() {
++        return this.JSON_TRANSLATION_FILE_PARSER;
++    }
++
++    @Override
++    public @NotNull TranslationFileParser propertiesTranslationFileParser() {
++        return this.PROPERTIES_TRANSLATION_FILE_PARSER;
++    }
++
++    @Override
++    public @NotNull TranslationLocaleParser filenameTranslationLocaleParser() {
++        return FILENAME_TRANSLATION_LOCALE_PARSER;
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/SinglePluginTranslator.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/SinglePluginTranslator.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..02b2519f21b46a587a28a1b98ef75e3729aeeff2
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/SinglePluginTranslator.java
+@@ -0,0 +1,42 @@
++package dev.lynxplay.ktp.adventure.translation;
++
++import net.kyori.adventure.key.Key;
++import net.kyori.adventure.translation.Translator;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.text.MessageFormat;
++import java.util.Locale;
++
++/**
++ * An implementation of the adventure translator interface that holds onto a {@link PluginTranslationBundle} of a specific plugin's namespace.
++ */
++public class SinglePluginTranslator implements Translator {
++
++    private final String namespaceSuffixedDot;
++    private final Key key;
++    private final PluginTranslationBundle translationBundle;
++
++    @SuppressWarnings("PatternValidation") // Key#key(String,String) will perform pattern validation, we do not have to enforce the pattern early.
++    public SinglePluginTranslator(@NotNull String namespace, @NotNull PluginTranslationBundle translationBundle) {
++        this.namespaceSuffixedDot = namespace + ".";
++        this.key = Key.key(namespace, "translations");
++        this.translationBundle = translationBundle;
++    }
++
++    @Override
++    public @NotNull Key name() {
++        return this.key;
++    }
++
++    @Override
++    public @Nullable MessageFormat translate(@NotNull String key, @NotNull Locale locale) {
++        if (!key.startsWith(namespaceSuffixedDot)) return null;
++
++        var translation = this.translationBundle.findTranslation(locale, key);
++        if (translation == null) translation = this.translationBundle.findTranslation(Locale.ENGLISH, key);
++
++        return translation == null ? null : new PluginShortcutMessageFormat(translation);
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/FilenameTranslationLocaleParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/FilenameTranslationLocaleParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ee5ff959e783071cee22832d3699bdec27babc13
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/FilenameTranslationLocaleParser.java
+@@ -0,0 +1,30 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationLocaleParserException;
++import net.kyori.adventure.translation.Translator;
++import org.apache.commons.lang.StringUtils;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Path;
++import java.util.Locale;
++
++/**
++ * An implementation of the {@link TranslationLocaleParser} that parses the locale of a file simply based on the base file name, ignoring the
++ * extension.
++ * <p>
++ * Example given:
++ * The file 'plugins/Example/language/en.json' would be parsed to {@link java.util.Locale#ENGLISH}.
++ * Notably this uses {@link net.kyori.adventure.translation.Translator#parseLocale(String)}, so country code and variants are also accepted.
++ */
++public final class FilenameTranslationLocaleParser implements TranslationLocaleParser {
++
++    @Override
++    public @NotNull Locale parseLocale(@NotNull Path path) throws TranslationLocaleParserException {
++        final var fileName = StringUtils.substringBeforeLast(path.getFileName().toString(), ".");
++        final var parsedLocale = Translator.parseLocale(fileName);
++        if (parsedLocale == null) throw new TranslationLocaleParserException("Failed to parse locale from " + path.getFileName().toString());
++
++        return parsedLocale;
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/JsonTranslationFileParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/JsonTranslationFileParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..333a05075a27386d008ac8974c2a51cd87fd084b
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/JsonTranslationFileParser.java
+@@ -0,0 +1,83 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import com.google.gson.Gson;
++import com.google.gson.GsonBuilder;
++import com.google.gson.JsonElement;
++import com.google.gson.JsonObject;
++import com.google.gson.JsonPrimitive;
++import com.google.gson.JsonSyntaxException;
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
++import org.jetbrains.annotations.NotNull;
++
++import java.io.IOException;
++import java.io.InputStreamReader;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.util.Map;
++
++/**
++ * A json based implementation of the translation file parser.
++ * Json files are parsed by constructing the translation key as a combination of each node above a value.
++ * <p>
++ * Example given:
++ * <pre>
++ * {
++ *   "message": {
++ *     "player": {
++ *       "join": "You joined the game"
++ *     }
++ *   }
++ * }
++ * </pre>
++ * would be parsed into a single translation, namely the translation key 'message.player.join' mapped to 'You joined the game'.
++ */
++public final class JsonTranslationFileParser implements TranslationFileParser {
++
++    private static final int PATH_STRING_BUFFER_LENGTH = 256; // Allocating more characters to the string builder to hopefully avoid re-allocation
++    // while building.
++    private final Gson gsonInstance = new GsonBuilder().disableHtmlEscaping().create();
++
++    @Override
++    public @NotNull Map<String, String> parseTranslations(@NotNull Path file) throws TranslationParseException {
++        try (
++            final var inputStream = Files.newInputStream(file);
++            final var inputStreamReader = new InputStreamReader(inputStream)
++        ) {
++            final var result = new Object2ObjectOpenHashMap<String, String>();
++            final var root = gsonInstance.fromJson(inputStreamReader, JsonElement.class);
++
++            crawl(result, new StringBuilder(PATH_STRING_BUFFER_LENGTH), root);
++
++            return result;
++        } catch (final IOException e) {
++            throw new TranslationParseException("Failed to read the translation file", e);
++        } catch (JsonSyntaxException e) {
++            throw new TranslationParseException("Failed to parse the translation file's json file", e);
++        }
++    }
++
++    /**
++     * The crawl method is a recursive method that crawls through the entire tree represented by the passed element and stores each value found
++     * inside the passed flattenedMap.
++     *
++     * @param flattenedMap the result map that flattened values will be inserted into.
++     * @param path         the current path to the passed element onto which new elements should be appended.
++     * @param element      the current root element which should be crawled.
++     */
++    private void crawl(@NotNull final Map<String, String> flattenedMap, @NotNull final StringBuilder path, @NotNull final JsonElement element) {
++        if (element instanceof JsonObject jsonObject) {
++            for (final var entry : jsonObject.entrySet()) {
++                if (!path.isEmpty()) path.append("."); // Only pre-pend if the path already has elements
++                path.append(entry.getKey()); // Push path
++
++                crawl(flattenedMap, path, entry.getValue());
++
++                path.setLength(Math.max(0, path.length() - (entry.getKey().length() + 1))); // Drop path addition, might be -1 on the root element.
++            }
++        } else if (element instanceof JsonPrimitive jsonPrimitive) {
++            flattenedMap.put(path.toString(), jsonPrimitive.getAsString());
++        }
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/PropertiesTranslationFileParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/PropertiesTranslationFileParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..40f2218d978494fd5bfdbddab57bb422f5d09eb3
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/PropertiesTranslationFileParser.java
+@@ -0,0 +1,41 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
++import org.jetbrains.annotations.NotNull;
++
++import java.io.IOException;
++import java.nio.charset.StandardCharsets;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.util.Map;
++import java.util.PropertyResourceBundle;
++
++/**
++ * A properties-based implementation of the translation file parser.
++ * Since properties files cannot contain hierarchical data, the mappings are taken verbatim from the file.
++ * <p>
++ * Example given:
++ * <pre>
++ *  message.player.join=You joined the game
++ * </pre>
++ * would be parsed as a translation mapping the key 'message.player.join' to the value 'You joined the game'.
++ * </p>
++ */
++public final class PropertiesTranslationFileParser implements TranslationFileParser {
++
++    @Override
++    public @NotNull Map<String, String> parseTranslations(@NotNull Path file) throws TranslationParseException {
++        final var translations = new Object2ObjectOpenHashMap<String, String>();
++
++        try (final var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
++            final var bundle = new PropertyResourceBundle(reader);
++            bundle.keySet().forEach(key -> translations.put(key, bundle.getString(key)));
++        } catch (final IOException e) {
++            throw new TranslationParseException("Failed to read the translation file", e);
++        }
++
++        return translations;
++    }
++
++}
+diff --git a/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/YamlTranslationFileParser.java b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/YamlTranslationFileParser.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..454b0e47c14103e05b5efdf88ccce965188ac6eb
+--- /dev/null
++++ b/src/main/java/dev/lynxplay/ktp/adventure/translation/parser/YamlTranslationFileParser.java
+@@ -0,0 +1,53 @@
++package dev.lynxplay.ktp.adventure.translation.parser;
++
++import dev.lynxplay.ktp.adventure.translation.exception.TranslationParseException;
++import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
++import org.bukkit.configuration.InvalidConfigurationException;
++import org.bukkit.configuration.file.YamlConfiguration;
++import org.jetbrains.annotations.NotNull;
++
++import java.io.IOException;
++import java.nio.charset.StandardCharsets;
++import java.nio.file.Files;
++import java.nio.file.Path;
++import java.util.Map;
++
++/**
++ * A yaml based implementation of the translation file parser.
++ * Yaml files are parsed by constructing the translation key as a combination of each node above a value.
++ * <p>
++ * Example given:
++ * <pre>
++ * message:
++ *   player:
++ *     join: 'You joined the game'
++ * </pre>
++ * would be parsed into a single translation, namely the translation key 'message.player.join' mapped to 'You joined the game'.
++ */
++public final class YamlTranslationFileParser implements TranslationFileParser {
++
++    @Override
++    public @NotNull Map<String, String> parseTranslations(@NotNull Path file) throws TranslationParseException {
++        try {
++            final var fileContent = Files.readString(file, StandardCharsets.UTF_8);
++            final var result = new Object2ObjectOpenHashMap<String, String>();
++
++            final var yaml = new YamlConfiguration();
++            yaml.loadFromString(fileContent);
++
++            for (final var key : yaml.getKeys(true)) {
++                final var value = yaml.getString(key, null);
++                if (value == null) continue;
++
++                result.put(key, value);
++            }
++
++            return result;
++        } catch (final IOException e) {
++            throw new TranslationParseException("Failed to read the translation file", e);
++        } catch (InvalidConfigurationException e) {
++            throw new TranslationParseException("Failed to parse the translation file's yaml file", e);
++        }
++    }
++
++}
+diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+index f763a3ea5796737304e0c1f41349622e1d7adadf..02fb6c638ac3286bb49401efa201975ada806494 100644
+--- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
++++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+@@ -1,6 +1,7 @@
+ package io.papermc.paper.adventure;
+ 
+ import com.mojang.brigadier.exceptions.CommandSyntaxException;
++import dev.lynxplay.ktp.adventure.translation.KTPTranslator;
+ import io.netty.util.AttributeKey;
+ import java.io.IOException;
+ import java.util.ArrayList;
+@@ -47,7 +48,7 @@ public final class PaperAdventure {
+             if (!Language.getInstance().has(translatable.key())) {
+                 for (final Translator source : GlobalTranslator.get().sources()) {
+                     if (source instanceof TranslationRegistry registry && registry.contains(translatable.key())) {
+-                        consumer.accept(GlobalTranslator.render(translatable, Locale.US));
++                        consumer.accept(KTPTranslator.render(translatable, Locale.US)); // KTP
+                         return;
+                     }
+                 }
+@@ -177,7 +178,7 @@ public final class PaperAdventure {
+ 
+     public static String asJsonString(final Component component, final Locale locale) {
+         return GSON.serialize(
+-            GlobalTranslator.render(
++            KTPTranslator.render( // KTP
+                 component,
+                 // play it safe
+                 locale != null
+@@ -196,7 +197,7 @@ public final class PaperAdventure {
+ 
+     public static String asPlain(final Component component, final Locale locale) {
+         return PLAIN.serialize(
+-            GlobalTranslator.render(
++            KTPTranslator.render( // KTP
+                 component,
+                 // play it safe
+                 locale != null
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 621ec8e8a197323da6b423fee57c816ac9d7c875..94c0fc4ad061e261e6cc4848557c61c7325d9f61 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1966,7 +1966,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+         // Paper start - Adventure
+         quitMessage = quitMessage == null ? this.server.getPlayerList().disconnect(this.player) : this.server.getPlayerList().disconnect(this.player, quitMessage); // Paper - pass in quitMessage to fix kick message not being used
+         if ((quitMessage != null) && !quitMessage.equals(net.kyori.adventure.text.Component.empty())) {
+-            this.server.getPlayerList().broadcastMessage(PaperAdventure.asVanilla(quitMessage), ChatType.SYSTEM, Util.NIL_UUID);
++            this.server.getPlayerList().broadcastMessage(quitMessage, ChatType.SYSTEM, Util.NIL_UUID); // KTP - use adventure-compatible broadcast
+             // Paper end
+         }
+         // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index eaa005c1c9b4386bcdbe1d6eb28c3eca7635066c..ef89dac350cc4543da1adebf4771418a7843bfb3 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -366,10 +366,9 @@ public abstract class PlayerList {
+         final net.kyori.adventure.text.Component jm = playerJoinEvent.joinMessage();
+ 
+         if (jm != null && !jm.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
+-            joinMessage = PaperAdventure.asVanilla(jm); // Paper - Adventure
+-            // Paper start - Removed sendAll for loop and broadcasted to console also
+-            this.server.getPlayerList().broadcastMessage(joinMessage, ChatType.SYSTEM, Util.NIL_UUID); // Paper - Adventure
+-            // Paper end
++            // KTP start
++            this.server.getPlayerList().broadcastMessage(jm, ChatType.SYSTEM, Util.NIL_UUID); // Perish, paper. Use adventure-compatible broadcast.
++            // KTP end
+         }
+         // CraftBukkit end
+ 
+@@ -1408,6 +1407,14 @@ public abstract class PlayerList {
+ 
+     }
+ 
++    // KTP start
++    public void broadcastMessage(net.kyori.adventure.text.Component component, ChatType type, UUID sender) {
++        final var identity = net.kyori.adventure.identity.Identity.identity(sender);
++        final var messageType = type == ChatType.CHAT ? net.kyori.adventure.audience.MessageType.CHAT : net.kyori.adventure.audience.MessageType.SYSTEM;
++        this.server.server.sendMessage(identity, component, messageType);
++    }
++    // KTP end
++
+     public void broadcastMessage(Component serverMessage, Function<ServerPlayer, Component> playerMessageFactory, ChatType playerMessageType, UUID sender) {
+         this.server.sendMessage(serverMessage, sender);
+         Iterator iterator = this.players.iterator();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 2e032a4e564174571c4ff983e13600bc75fa9058..589bf52bb1ed2c14380e1a92028c4970fcbf9945 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -292,6 +292,7 @@ public final class CraftServer implements Server {
+     private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
+     public static Exception excessiveVelEx; // Paper - Velocity warnings
+     private final SysoutCatcher sysoutCatcher = new SysoutCatcher(); // Paper
++    private final dev.lynxplay.ktp.adventure.translation.PluginTranslators pluginTranslators; // KTP - plugin translators - server instance
+ 
+     static {
+         ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
+@@ -376,6 +377,7 @@ public final class CraftServer implements Server {
+         this.minimumAPI = this.configuration.getString("settings.minimum-api");
+         this.loadIcon();
+         datapackManager = new io.papermc.paper.datapack.PaperDatapackManager(console.getPackRepository()); // Paper
++        this.pluginTranslators = new dev.lynxplay.ktp.adventure.translation.PluginTranslatorsImpl(); // KTP - plugin translators - server instance
+     }
+ 
+     public boolean getCommandBlockOverride(String command) {
+@@ -2720,4 +2722,14 @@ public final class CraftServer implements Server {
+     }
+ 
+     // Paper end
++    // KTP start
++    /**
++     * Returns the plugin translator of the server that plugins may use to register custom translations.
++     * @return the plugin translator instance.
++     */
++    @Override
++    public @org.jetbrains.annotations.NotNull dev.lynxplay.ktp.adventure.translation.PluginTranslators pluginTranslators() {
++        return this.pluginTranslators;
++    }
++    // KTP end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+index dbff1eda25b02b16ec123515338d470489f3b3c4..6fa10a9fc11d17516a582594131623027fa5a0c9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+@@ -91,7 +91,8 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
+     // Paper start
+     @Override
+     public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component message, final net.kyori.adventure.audience.MessageType type) {
+-        this.sendRawMessage(io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.serialize(message));
++        final var textComponent = net.kyori.adventure.translation.GlobalTranslator.render(message, java.util.Locale.getDefault()); // KTP - render to prevent non-serializable component from being sent
++        this.sendRawMessage(io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.serialize(textComponent));
+     }
+ 
+     @Override


### PR DESCRIPTION
This patch implements the mini translatable component interface and
implementation that is an additional component that may be used in
combination with the adventure text api.

A mini translatable component is a translatable-like component that only
holds a key that is matched to a localized message when rendered. The
difference between a translatable component and a mini translatable
component is the fact that the translation the mini translatable
component represents is parsed using the mini message parser and
arguments are passed in as a single template resolver.

Things left for this PR to be out of draft:

- [x] Rename the component to `PluginTranslatableComponent`
- [x] Testing the functionality
- [x] Implement json and property translation file parser
- [x] Updating the patch name and description