### PR TITLE
Add test plugin layout to ease testing api changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ run
 ktp-paperclip.jar
 
 !gradle/wrapper/gradle-wrapper.jar
+
+test-plugin.settings.gradle.kts

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,3 +8,10 @@ pluginManagement {
 rootProject.name = "ktp"
 
 include("KTP-API", "KTP-Server")
+
+val testPlugin = file("test-plugin.settings.gradle.kts")
+if (testPlugin.exists()) {
+    apply(from = testPlugin)
+} else {
+    testPlugin.writeText("// Uncomment to enable the test plugin module\n//include(\":test-plugin\")\n")
+}

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -1,0 +1,30 @@
+version = "1.0.0-SNAPSHOT"
+
+repositories {
+    maven("https://libraries.minecraft.net")
+}
+
+dependencies {
+    compileOnly(project(":KTP-API"))
+    compileOnly("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT")
+
+    testImplementation(project(":KTP-API"))
+    testImplementation("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT")
+    testImplementation(platform("org.junit:junit-bom:5.8.1"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+}
+
+tasks.processResources {
+    inputs.property("version", project.version)
+    filesMatching("plugin.yml") {
+        expand("version" to project.version)
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events.addAll(listOf("PASSED", "SKIPPED", "FAILED").map { org.gradle.api.tasks.testing.logging.TestLogEvent.valueOf(it) })
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}

--- a/test-plugin/src/main/java/dev/lynxplay/ktp/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/dev/lynxplay/ktp/testplugin/TestPlugin.java
@@ -1,0 +1,11 @@
+package dev.lynxplay.ktp.testplugin;
+
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class TestPlugin extends JavaPlugin implements Listener {
+    @Override
+    public void onEnable() {
+        this.getServer().getPluginManager().registerEvents(this, this);
+    }
+}

--- a/test-plugin/src/main/resources/plugin.yml
+++ b/test-plugin/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: ktp-test-plugin
+version: ${version}
+main: dev.lynxplay.ktp.testplugin.TestPlugin
+description: KTP testing plugin
+author: KTP
+api-version: 1.17
+load: STARTUP

--- a/test-plugin/src/test/java/dev/lynxplay/ktp/testplugin/JavaTest.java
+++ b/test-plugin/src/test/java/dev/lynxplay/ktp/testplugin/JavaTest.java
@@ -1,0 +1,11 @@
+package dev.lynxplay.ktp.testplugin;
+
+import org.junit.jupiter.api.Test;
+
+public class JavaTest {
+
+    @Test
+    public void exampleTest() {
+
+    }
+}


### PR DESCRIPTION
To ease testing new additions to the api, this commit adds a test plugin
that may be used to develop locally. The test plugin will automatically
be added to any server ran through 'runDev' or the likes if enabled.

To ensure no changes to the test plugin are commited to the repository,
it has to be excluded from git future tracking through the following
bash commands:
 - echo "test-plugin" >> .git/info/exclude
 - find test-plugin -type f | xargs git update-index --assume-unchanged
And uncommenting the include line in 'test-plugin.settings.gradle.kt'.