### PR TITLE
Exclude paper api from test plugin dependencies

### DIFF
--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -2,16 +2,21 @@ version = "1.0.0-SNAPSHOT"
 
 repositories {
     maven("https://libraries.minecraft.net")
+    mavenCentral()
 }
 
 dependencies {
     compileOnly(project(":KTP-API"))
-    compileOnly("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT") {
+        exclude("io.papermc.paper", "paper-api")
+    }
 
     testImplementation(project(":KTP-API"))
-    testImplementation("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-mojangapi:1.17.1-R0.1-SNAPSHOT") {
+        exclude("io.papermc.paper", "paper-api")
+    }
     testImplementation(platform("org.junit:junit-bom:5.8.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 }
 
 tasks.processResources {


### PR DESCRIPTION
The paper mojang api transitively includes the paper-api which conflicts
with importing the forks own api files, resulting in problems resolving
api additions to the forks api files.

This commit now excludes the paper-api from the mojang-api dependency
for the test plugin.