### PR TITLE
Add #getConfigurationSectionList to yaml API

### DIFF
--- a/patches/api/0010-Add-getConfigurationSectionList-to-yaml-API.patch
+++ b/patches/api/0010-Add-getConfigurationSectionList-to-yaml-API.patch
@@ -1,0 +1,137 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Thu, 3 Mar 2022 17:10:48 +0100
+Subject: [PATCH] Add #getConfigurationSectionList to yaml API
+
+The yaml parser does not consider yaml sections that are defined as part
+of a list, configuration sections but rather simple maps. This makes
+interaction with theses sections rather difficult.
+
+To ease interaction, this patch creates a new getter in the
+configuration section interface that returns a list of configuration
+sections by actively converting the parsed maps into memory sections.
+
+diff --git a/src/main/java/org/bukkit/configuration/ConfigurationSection.java b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+index 715ef162dae2b538317d40b2a9f246db994d6b52..b4153fb9a190f9d1f9e559187b6ae763d3b42b34 100644
+--- a/src/main/java/org/bukkit/configuration/ConfigurationSection.java
++++ b/src/main/java/org/bukkit/configuration/ConfigurationSection.java
+@@ -996,4 +996,22 @@ public interface ConfigurationSection {
+      * @throws IllegalArgumentException Thrown if path is null.
+      */
+     public void addDefault(@NotNull String path, @Nullable Object value);
++
++    // KTP start - expose lists of configuration sections
++
++    /**
++     * Gets the requested list of configuration sections by their poth.
++     * <p>
++     * If the list does not exist but a default value has been specified, this
++     * will return the default value. If the list does not exist and no
++     * default value was specified, this will return an empty List.
++     * <p>
++     * This method will attempt to convert any form of map into a configuration section
++     * before returning it.
++     *
++     * @param path the fully qualified path to the list of configuration sections.
++     * @return the requested list of configuration sections.
++     */
++    @NotNull List<@NotNull ConfigurationSection> getConfigurationSectionList(@NotNull String path);
++    // KTP end - expose lists of configuration sections
+ }
+diff --git a/src/main/java/org/bukkit/configuration/MemorySection.java b/src/main/java/org/bukkit/configuration/MemorySection.java
+index 90cc523f658f3632d4dbdec3a5d2ce7c3c02341f..398efc32ee3ee430c9f3c12bb8d33cac0042c90d 100644
+--- a/src/main/java/org/bukkit/configuration/MemorySection.java
++++ b/src/main/java/org/bukkit/configuration/MemorySection.java
+@@ -971,4 +971,38 @@ public class MemorySection implements ConfigurationSection {
+             .append("']")
+             .toString();
+     }
++    // KTP start - expose lists of configuration sections
++    /**
++     * Gets the requested list of configuration sections by their poth.
++     * <p>
++     * If the list does not exist but a default value has been specified, this
++     * will return the default value. If the list does not exist and no
++     * default value was specified, this will return an empty List.
++     * <p>
++     * This method will attempt to convert any form of map into a configuration section
++     * before returning it.
++     *
++     * @param path the fully qualified path to the list of configuration sections.
++     * @return the requested list of configuration sections.
++     */
++    @SuppressWarnings("unchecked")
++    @Override
++    public @NotNull List<@NotNull ConfigurationSection> getConfigurationSectionList(@NotNull final String path) {
++        final var list = this.getList(path);
++        if (list == null) return new ArrayList<>(0);
++
++        final var mappedList = new ArrayList<ConfigurationSection>(list.size());
++        for (final var object : list) {
++            if (object instanceof ConfigurationSection configurationSection) {
++                mappedList.add(configurationSection);
++            } else if (object instanceof java.util.HashMap hashMap) {
++                final var mappedConfigurationSection = new MemorySection(this, path);
++                org.bukkit.configuration.file.YamlConfiguration.convertMapsToSections(hashMap, mappedConfigurationSection);
++                mappedList.add(mappedConfigurationSection);
++            }
++        }
++
++        return mappedList;
++    }
++    // KTP end - expose lists of configuration sections
+ }
+diff --git a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+index 6476f3794b0c3815486c87968a71d0c572f3a89a..83652af10a5e4682d23da252f235fd2873f84385 100644
+--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
++++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+@@ -73,7 +73,7 @@ public class YamlConfiguration extends FileConfiguration {
+         }
+     }
+ 
+-    protected void convertMapsToSections(@NotNull Map<?, ?> input, @NotNull ConfigurationSection section) {
++    public static void convertMapsToSections(@NotNull Map<?, ?> input, @NotNull ConfigurationSection section) { // KTP - expose globally as it is a pure method
+         for (Map.Entry<?, ?> entry : input.entrySet()) {
+             String key = entry.getKey().toString();
+             Object value = entry.getValue();
+diff --git a/src/test/java/dev/lynxplay/ktp/configuration/GetConfigurationSectionListTest.java b/src/test/java/dev/lynxplay/ktp/configuration/GetConfigurationSectionListTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..76b766048110cdf41fdeb120a3ee7ca2cda79f5b
+--- /dev/null
++++ b/src/test/java/dev/lynxplay/ktp/configuration/GetConfigurationSectionListTest.java
+@@ -0,0 +1,35 @@
++package dev.lynxplay.ktp.configuration;
++
++import org.bukkit.configuration.InvalidConfigurationException;
++import org.bukkit.configuration.file.YamlConfiguration;
++import org.junit.Assert;
++import org.junit.Test;
++
++public class GetConfigurationSectionListTest {
++
++    private static final String YAML_CONTENT = """
++        list:
++          - name: 'lynxplay'
++            role: 'developer'
++          - name: 'carter'
++            role: 'admiral'
++        """;
++
++    @Test
++    public void testGetConfigurationSectionList() throws InvalidConfigurationException {
++        final var config = new YamlConfiguration();
++        config.loadFromString(YAML_CONTENT);
++
++        final var configSectionList = config.getConfigurationSectionList("list");
++        Assert.assertEquals(2, configSectionList.size());
++
++        final var lynxplay = configSectionList.get(0);
++        Assert.assertEquals("lynxplay", lynxplay.getString("name"));
++        Assert.assertEquals("developer", lynxplay.getString("role"));
++
++        final var carter = configSectionList.get(1);
++        Assert.assertEquals("carter", carter.getString("name"));
++        Assert.assertEquals("private", carter.getString("role"));
++    }
++
++}


### PR DESCRIPTION
The yaml parser does not consider yaml sections that are defined as part
of a list, configuration sections but rather simple maps. This makes
interaction with theses sections rather difficult.

To ease interaction, this commit creates a new getter in the
configuration section interface that returns a list of configuration
sections by actively converting the parsed maps into memory sections.