### PR TITLE
Add considerInvalidMessageSignatureAsUnsigned

### DIFF
--- a/patches/server/0015-Add-considerInvalidMessageSignatureAsUnsigned.patch
+++ b/patches/server/0015-Add-considerInvalidMessageSignatureAsUnsigned.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Fri, 7 Apr 2023 21:42:19 +0200
+Subject: [PATCH] Add considerInvalidMessageSignatureAsUnsigned
+
+The considerInvalidMessageSignatureAsUnsigned option added by this patch
+allows the server to consider any player chat message that was sent that
+contains an invalid or missing signature to simply interpet as a
+unsigned message.
+
+This behaviour may break basically everything unless a respective plugin
+is in place to also map all messages to system messages, which is the
+case in the environment KTP is meant to be run.
+
+This patch is certainly not a final fix for the current problem facing
+the production environment ktp is deployed in, but works as a quick and
+dirty fix for the issue.
+
+diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+index 8d442c5a498ecf288a0cc0c54889c6e2fda849ce..ea6b6dbb374442c0d00607b61b291bef9f20f33a 100644
+--- a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
++++ b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
+@@ -143,6 +143,10 @@ public class GlobalConfiguration extends ConfigurationPart {
+         public boolean allowHeadlessPistons = false;
+         @Comment("This setting controls if grindstones should be able to output overstacked items (such as cursed books).")
+         public boolean allowGrindstoneOverstacking = false;
++        // KTP start - invalid signature unsigned message fallback
++        @Comment("This setting controls if the server should consider a message with an invalid or missing signature as unsigned or not")
++        public boolean considerInvalidMessageSignatureAsUnsigned = false;
++        // KTP end - invalid signature unsigned message fallback
+     }
+ 
+     public Commands commands;
+diff --git a/src/main/java/net/minecraft/network/chat/SignedMessageChain.java b/src/main/java/net/minecraft/network/chat/SignedMessageChain.java
+index c0a80824a0307ea673805015119cc834b268f0dc..af908a96608c32f716dd5836694cae0c94bc1cad 100644
+--- a/src/main/java/net/minecraft/network/chat/SignedMessageChain.java
++++ b/src/main/java/net/minecraft/network/chat/SignedMessageChain.java
+@@ -39,6 +39,11 @@ public class SignedMessageChain {
+             } else {
+                 PlayerChatMessage playerChatMessage = new PlayerChatMessage(signedMessageLink, signature, body, (Component)null, FilterMask.PASS_THROUGH);
+                 if (!playerChatMessage.verify(signatureValidator)) {
++                    // KTP start - invalid signature unsigned message fallback
++                    if (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.considerInvalidMessageSignatureAsUnsigned) {
++                        return new PlayerChatMessage(signedMessageLink, null, body, null, FilterMask.PASS_THROUGH);
++                    }
++                    // KTP end - invalid signature unsigned message fallback
+                     throw new SignedMessageChain.DecodeException(Component.translatable("multiplayer.disconnect.unsigned_chat"), true, org.bukkit.event.player.PlayerKickEvent.Cause.UNSIGNED_CHAT); // Paper - kick event causes
+                 } else {
+                     if (playerChatMessage.hasExpiredServer(Instant.now())) {


### PR DESCRIPTION
The considerInvalidMessageSignatureAsUnsigned option added by this patch allows the server to consider any player chat message that was sent that contains an invalid or missing signature to simply interpet as a unsigned message.

This behaviour may break basically everything unless a respective plugin is in place to also map all messages to system messages, which is the case in the environment KTP is meant to be run.

This patch is certainly not a final fix for the current problem facing the production environment ktp is deployed in, but works as a quick and dirty fix for the issue.