### PR TITLE
Add fluent item meta edit helpers

### DIFF
--- a/patches/api/0015-Add-fluent-item-meta-edit-helpers.patch
+++ b/patches/api/0015-Add-fluent-item-meta-edit-helpers.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Fri, 21 Apr 2023 00:46:58 +0200
+Subject: [PATCH] Add fluent item meta edit helpers
+
+To ease small modifications to an item stack in plugins depending on
+ktp, this patch adds two new helper methods that shadow papers
+ItemStack#editMeta methods but return the mutated item stack for
+consumption or further edits instead of a result boolean.
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index d15a74c38576c49df61cfab02c70fc5d8c0dd5f7..857c35b0bd9f6878621aaacf8496430fb7d9a88b 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -590,6 +590,55 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+         return false;
+     }
+     // Paper end
++    // KTP start - fluent meta edit helpers
++
++    /**
++     * Edits the {@link ItemMeta} of this stack.
++     * <p>
++     * The {@link java.util.function.Consumer} must only interact
++     * with this stack's {@link ItemMeta} through the provided {@link ItemMeta} instance.
++     * Calling this method or any other meta-related method of the {@link ItemStack} class
++     * (such as {@link #getItemMeta()}, {@link #addItemFlags(ItemFlag...)}, {@link #lore()}, etc.)
++     * from inside the consumer is disallowed and will produce undefined results or exceptions.
++     * </p>
++     * Whether this method could apply the consumer to this item stack is not defined by a return value.
++     * If such result oriented data is required, use {@link #editMeta(Class, java.util.function.Consumer)}.
++     *
++     * @param consumer the meta consumer
++     *
++     * @return this item stack instance but mutated with the modified item meta produced by the passed consumer
++     */
++    @org.jetbrains.annotations.Contract("_ -> this")
++    public <M extends ItemMeta> ItemStack withMeta(final @NotNull java.util.function.Consumer<@NotNull ItemMeta> consumer) {
++        this.editMeta(consumer);
++        return this;
++    }
++
++    /**
++     * Edits the {@link ItemMeta} of this stack if the meta is of the specified type.
++     * <p>
++     * The {@link java.util.function.Consumer} must only interact
++     * with this stack's {@link ItemMeta} through the provided {@link ItemMeta} instance.
++     * Calling this method or any other meta-related method of the {@link ItemStack} class
++     * (such as {@link #getItemMeta()}, {@link #addItemFlags(ItemFlag...)}, {@link #lore()}, etc.)
++     * from inside the consumer is disallowed and will produce undefined results or exceptions.
++     * </p>
++     * Whether this method could apply the consumer to this item stack is not defined by a return value.
++     * If such result oriented data is required, use {@link #editMeta(Class, java.util.function.Consumer)}.
++     *
++     * @param metaClass the type of meta to edit
++     * @param consumer  the meta consumer
++     * @param <M>       the meta type
++     *
++     * @return this item stack instance but mutated with the modified item meta produced by the passed consumer
++     */
++    @org.jetbrains.annotations.Contract("_,_ -> this")
++    public <M extends ItemMeta> ItemStack withMeta(final @NotNull Class<M> metaClass,
++                                                   final @NotNull java.util.function.Consumer<@NotNull ? super M> consumer) {
++        this.editMeta(metaClass, consumer);
++        return this;
++    }
++    // KTP stop - fluent meta edit helpers
+ 
+     /**
+      * Get a copy of this ItemStack's {@link ItemMeta}.


### PR DESCRIPTION
To ease small modifications to an item stack in plugins depending on ktp, this patch adds two new helper methods that shadow papers ItemStack#editMeta methods but return the mutated item stack for consumption or further edits instead of a result boolean.